### PR TITLE
💄 Fix link underline bleeding

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -876,7 +876,7 @@ ul .task-list-item ul::before {
   text-decoration: none;
 }
 
-.cm-s-obsidian span.cm-link {
+.cm-s-obsidian span.cm-link:not(.cm-formatting-link) {
   background-image: linear-gradient(
     to bottom,
     var(--bg-sub-accent-55) 0%,


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5908498/135755177-3ad1af0b-5eda-4a4f-926d-72067f12b25e.png)


After:
![image](https://user-images.githubusercontent.com/5908498/135755155-1ba17044-fdde-4678-9057-3273c84bd389.png)

Since it's fairly hard to tell what the change is here is another picture:
![image](https://user-images.githubusercontent.com/5908498/135766788-d1eda77e-8568-4a94-b992-cb15b43b1950.png)

