### PR TITLE
Fixed code block bug

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -1065,7 +1065,7 @@ h6 a.tag {
 }
 
 .cm-s-obsidian div.HyperMD-codeblock-begin-bg:before {
-  position: absolute;
+  position: relative;
   content: '';
   top: -5%;
   left: 0;


### PR DESCRIPTION
Every code block will create a 'before' element when it has been created,
It is using an absolute positioning, and will cover other areas.
I turned it into relative positioning to fix it.