### PR TITLE
Fixed bold selection

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -719,7 +719,7 @@ pre.HyperMD-header.HyperMD-header-6 {
 strong {
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
-  padding: 0 0.1rem;
+  padding: 0;
   color: #7aa2f7;
   background-color: #7aa2f7;
   background-image: linear-gradient(62deg, #87c2fd 0%, #dcb9fc 100%) !important;
@@ -729,7 +729,7 @@ strong .math.math-inline .MathJax {
   position: inherit !important;
 }
 
-.cm-strong::selection,
+.cm-strong .cm-selection,
 strong::selection {
   -webkit-text-fill-color: var(--text-faint);
 }


### PR DESCRIPTION
Previously selecting bold text in the editor mode caused some unusual behaviour (namely selected text was invisible and the padding caused text to move as it was selected)

This is because the ::selection pseudo-element isnt defined for CodeMirror elements, I just replaced it with the correct CodeMirror selection element.