### PR TITLE
💄 Fix link underline in live preview mode

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -766,6 +766,11 @@ ul .task-list-item ul::before {
 | LINKS STYLING
 **--------------------**/
 
+/** live preview mode **/
+.markdown-source-view.mod-cm6 .cm-underline {
+  text-decoration: unset;
+}
+
 /** editor mode **/
 
 .cm-s-obsidian span.cm-link,


### PR DESCRIPTION
Fix #57 

Before:
![image](https://user-images.githubusercontent.com/5908498/194768128-2a220224-5ac7-4384-8dba-be886c8e2d9f.png)

After:
![image](https://user-images.githubusercontent.com/5908498/194768133-128f1109-236a-4855-93e2-6b5b4303f2f4.png)
