### PR TITLE
Use correct format for --interactive-accent-rgb

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -38,7 +38,7 @@
   --background-modifier-border: #92a1a17a;
   --blockquote-border: #d6555f;
   --tag-background: #a7b0b3;
-  --interactive-accent-rgb: #db4d52;
+  --interactive-accent-rgb: 61, 215, 251;
   --font-family-editor: Avenir, 'Avenir Next';
   --font-family-preview: Avenir, 'Avenir Next';
 } */


### PR DESCRIPTION
Fix #59 

Before
![image](https://user-images.githubusercontent.com/5908498/194786868-594ce7c2-ecad-4549-9c46-2e9bb94578c7.png)
![image](https://user-images.githubusercontent.com/5908498/194786880-ee2a3f73-434d-47c7-8ac0-1a083672238f.png)

After
![image](https://user-images.githubusercontent.com/5908498/194786889-9c68bcb0-3900-4c72-b2d1-f2500a492f87.png)
![image](https://user-images.githubusercontent.com/5908498/194786895-13e2593b-2e89-4ac4-b2ac-95651bc51c87.png)
