### PR TITLE
fix the displays exception of h3

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -533,7 +533,7 @@ h6 {
 .markdown-preview-section h3,
 .cm-header-3 {
   font-size: 22px;
-  color: var(--text-title-h2);
+  color: var(--text-title-h3);
 }
 
 .markdown-preview-section h4,


### PR DESCRIPTION
h3 display abnormally in my Obsidian. In the code I found that h3 was miswritten as h2.