### PR TITLE
Thinner lines between multiple blockquotes in live preview mode

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -1096,6 +1096,10 @@ blockquote {
   background: linear-gradient(90deg, rgba(13, 185, 215, 0.5), #13111a);
 }
 
+.markdown-source-view.mod-cm6.is-live-preview .HyperMD-quote + .HyperMD-quote::before {
+  display: none;
+}
+
 .HyperMD-quote::after,
 .markdown-preview-view blockquote::after {
   content: '';


### PR DESCRIPTION
Fix #62 

Before: 
![image](https://user-images.githubusercontent.com/5908498/195846127-6db7ae4e-227e-4650-8c97-b581058d5ad6.png)

After:
![image](https://user-images.githubusercontent.com/5908498/195846214-4b7b228b-2ab5-48be-b4bd-f3d5ce6b1167.png)
