### PR TITLE
Hide code block flair box if it's empty

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -948,7 +948,7 @@ h6 a.tag {
 | CODE FENCE STYLING
 **--------------------**/
 
-.cm-s-obsidian span.code-block-flair {
+.cm-s-obsidian span.code-block-flair:not(:empty) {
   color: var(--text-accent);
   font-weight: 600;
   text-transform: uppercase;


### PR DESCRIPTION
This adheres to how Obsidian default theme behaves.

Fix #74 

Before
![image](https://user-images.githubusercontent.com/5908498/199005817-ced118f9-6704-4b9e-8cb8-61daed8cd742.png)

After
![image](https://user-images.githubusercontent.com/5908498/199005766-660f13ea-8126-4bad-bacb-0e870adcf53a.png)
