### PR TITLE
Better alignment for indentation line

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -677,6 +677,7 @@ em {
 .markdown-source-view.mod-cm6 .cm-indent::before {
   border-width: 2px;
   border-color: var(--text-accent);
+  margin-left: -1px;
   opacity: 0.35;
   transition: opacity 500ms linear ease-in-out;
 }


### PR DESCRIPTION
By default the indentation line width is 1px but since obsidiante sets it to 2px one can see a bit of an offset of the line.

Before
![image](https://user-images.githubusercontent.com/5908498/199019510-8aae6694-4490-4ae7-92ff-cdb217ab9b9f.png)

After
![image](https://user-images.githubusercontent.com/5908498/199019649-e66cfc08-8ce5-475e-97cd-b022731c9a60.png)

Partly fixes #71 