### PR TITLE
Fix layout shift from Side-dock borders

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -253,6 +253,10 @@ body .markdown-preview-section div {
 }
 
 /** NAVIGATION / SIDE-DOCK **/
+.nav-file-title,
+.nav-folder-title {
+  border: 1px solid transparent
+}
 
 .nav-folder-collapse-indicator {
   color: var(--text-accent);


### PR DESCRIPTION
Hi! I love the Obsidianite theme, it really helps me be more organized!

The only thing that really bothered me was the layout shift while hovering the Side-Dock menu, so I added an invisible border, that way the layout stays consistent even while hovering!