### PR TITLE
fix: quote block padding causing incorrect indentation

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -1002,7 +1002,7 @@ blockquote {
 .markdown-source-view.mod-cm6.is-live-preview .HyperMD-quote,
 .markdown-preview-view blockquote {
   position: relative;
-  padding: 1rem 2rem 1rem 3rem;
+  padding: 1rem 0rem 1rem 0rem;
   color: #bdbdbd;
   border-top-right-radius: 5px;
   border-bottom-right-radius: 5px;


### PR DESCRIPTION
Closes #101

- Obsidian 1.5.8 introduces changes to CSS documents, which has likely broken the way that blockquotes are rendered on the HTML document by the theme.
- Changes `padding` property on the `.HyperMD-quote` to use 0 padding on the left and right properties to reverse this change as a temporary fix.