### PR TITLE
Fixed external link text not visible

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -760,7 +760,7 @@ a,
 .cm-link {
   text-decoration: none !important;
   color: var(--text-normal);
-  position: relative;
+/*   position: relative; */
   z-index: 1;
 }
 


### PR DESCRIPTION
fixed an issue that prevents external links show as pink background instead of a text of the link.